### PR TITLE
Fixed error and exit when the input list ended with a newline character.

### DIFF
--- a/BAMixChecker.py
+++ b/BAMixChecker.py
@@ -54,7 +54,7 @@ def get_file_list(dir_path,user_file_list,FullPATH,flag_FNM):
 	if user_file_list != '':
 		fr_file_list = open(user_file_list,'r')
 		for line_fl in fr_file_list:
-			if line_fl.startswith('#'):
+			if line_fl.startswith('#') or line_fl.strip() == "":
 				continue
 			lis_fl = line_fl.strip().split('\t')
 			for fl in lis_fl:


### PR DESCRIPTION
It is common to have a text file end with a newline character. When there was a newline at the end of the input file that lists all the bam files it would result in an error because the empty line was seen as a file. This small change will fix that behaviour.